### PR TITLE
Support editing internal name

### DIFF
--- a/src/components/tracks_tab.py
+++ b/src/components/tracks_tab.py
@@ -190,14 +190,14 @@ class DiscListEntry(VirtualDiscListEntry):
         self._btnIcon = MultiDragDropButton(ButtonType.IMAGE, self)
         self._btnTrack = MultiDragDropButton(ButtonType.TRACK, self)
         self._leTitle = QFocusLineEdit("Track Title", self)
-        self._lblIName = QSubtitleLabel("internal name", self)
+        self._leIName = QFocusLineEdit("internal name", self)
         self._btnDelete = DeleteButton(self)
         self._btnUpArrow = ArrowButton(ButtonType.ARROW_UP, self)
         self._btnDownArrow = ArrowButton(ButtonType.ARROW_DOWN, self)
 
         self._leTitle.setMaxLength(Constants.LINE_EDIT_MAX_CHARS)
         self._leTitle.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.Preferred))
-        self._lblIName.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.Preferred))
+        self._leIName.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.Preferred))
 
         #container layout for icon button
         iconLayout = QtWidgets.QVBoxLayout()
@@ -213,9 +213,9 @@ class DiscListEntry(VirtualDiscListEntry):
 
         #scroll area to prevent internal name label from resizing DiscListEntry
         iNameScrollArea = QtWidgets.QScrollArea(self)
-        iNameScrollArea.setWidget(self._lblIName)
+        iNameScrollArea.setWidget(self._leIName)
         iNameScrollArea.setWidgetResizable(True)
-        iNameScrollArea.setMinimumHeight(self._lblIName.height())
+        iNameScrollArea.setMinimumHeight(self._leIName.height())
         iNameScrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         iNameScrollArea.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         iNameScrollArea.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.MinimumExpanding, QtWidgets.QSizePolicy.Maximum))
@@ -276,7 +276,7 @@ class DiscListEntry(VirtualDiscListEntry):
         self._btnIcon.setObjectName('ImageButton')
         self._btnTrack.setObjectName('TrackButton')
         self._leTitle.setObjectName('TitleLineEdit')
-        self._lblIName.setObjectName('INameLabel')
+        self._leIName.setObjectName('INameLabel')
         self._btnDelete.setObjectName('DeleteButton')
         self._btnUpArrow.setObjectName('ArrowUp')
         self._btnDownArrow.setObjectName('ArrowDown')
@@ -300,7 +300,7 @@ class DiscListEntry(VirtualDiscListEntry):
         return DiscListEntryContents(texture_file   = self._btnIcon.getFile(),
                                      track_file     = self._btnTrack.getFile(),
                                      title          = self._leTitle.text(),
-                                     internal_name  = self._lblIName.text())
+                                     internal_name  = self._leIName.text())
 
     def setEntry(self, entry_contents: DiscListEntryContents):
         self._btnIcon.setFile(entry_contents.texture_file)
@@ -313,7 +313,7 @@ class DiscListEntry(VirtualDiscListEntry):
         self._leTitle.setText(title)
 
     def setSubtitle(self, title: str):
-        self._lblIName.setText( Helpers.to_internal_name(title) )
+        self._leIName.setText( Helpers.to_internal_name(title) )
 
 
 

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -134,7 +134,7 @@ class Helpers():
     def to_internal_name(title: str) -> str:
         ascii_title = unidecode.unidecode(title)                                            #transliterate unicode letters to ascii
         numname_title = ''.join([ DigitNameDict.get(i, i) for i in ascii_title.lower() ])   #convert upper to lower-case, convert numbers to words
-        internal_name = ''.join([ i for i in numname_title if i.isalpha() ])                #strip non-alphabetic characters
+        internal_name = ''.join([ i for i in numname_title if i.isalnum() ])                #strip non-alphanumeric characters
         return internal_name
 
 class Assets():

--- a/src/generator/base.py
+++ b/src/generator/base.py
@@ -64,11 +64,11 @@ class VirtualGenerator():
                 raise IMDException(Status.BAD_INTERNAL_NAME)
 
             #internal names are letters-only
-            if(not e.internal_name.isalpha()):
+            if(not e.internal_name.isalnum()):
                 raise IMDException(Status.BAD_INTERNAL_NAME)
 
             #internal names are all lowercase
-            if(not e.internal_name.islower()):
+            if(not (e.internal_name.islower() or e.internal_name.isdecimal())):
                 raise IMDException(Status.BAD_INTERNAL_NAME)
 
         #if pack icon is provided


### PR DESCRIPTION
Hello, as described in issue #114, I found there is currently no way to edit the internal name of the music being added, which can be quite unwieldy to type: `/function <datapack_name>:give_<averylongandhardtowriteinternalid>`. At the time I simply went in and manually changed the long names into the short ones which I prefer, but I figured it would be good to be able to do that from the program that generated it in the first place, rather than having to do it manually.

Additionally, while making this change, I found that the program strips out numbers, which I don't think is necessary (AFAIK the game accepts identifiers conforming to the regex `^[a-z0-9_]+$`), so I have also altered the check for valid internal names to accept digits as well. I've only done 1 test case (my own datapack), but the game didn't complain and everything works as intended when I included numbers in the identifier.