### PR TITLE
Fixed version constraint on PySide6

### DIFF
--- a/requirements.rc
+++ b/requirements.rc
@@ -1,6 +1,6 @@
 pyinstaller~=5.13.2
 nuitka~=1.8.1
 pyffmpeg~=2.3.0.2
-PySide6==6.5.1
+PySide6>=6.5.1, <6.6.0
 mutagen~=1.47.0
 unidecode~=1.3.6


### PR DESCRIPTION
A fixed constraint on PySide6 in requirements.rc led to a problem described in issue #209.
This MR includes the proposed workaround from the issue.
It was tested on a single platform (same issue), so I'd like to know if the change may or have resulted in any breakage on different platforms.